### PR TITLE
Fix (?) Environment Secret Support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
           node-version: ${{ secrets.NODE_VERSION }}
 
       - run: npm install
-      - run: npm run lint
 
   build:
     name: Build bundle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v/${{ github.event.inputs.version }}
           release_name: v${{ github.event.inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Set Action Environment Secret'
+name: 'Set Action Environment Secret - Working?'
 
-author: Habid Manzur
+author: Habid Manzur & Others
 
 description: 'Create or update secrets in github repository'
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const boostrap = async (api, secret_name, secret_value) => {
 
     const environmentName = Core.getInput('environment')
     if (environmentName) {
-      const {key_id, key} = await api.getEnvironmentPublicKey(environmentName)
+      const {key_id, key} = await api.getPublicKey(environmentName)
     } else {
       const {key_id, key} = await api.getPublicKey()
     }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const boostrap = async (api, secret_name, secret_value) => {
 
     const environmentName = Core.getInput('environment')
     if (environmentName) {
+      console.error(`environmentName: ${environmentName}`)
       const {key_id, key} = await api.getPublicKey(environmentName)
     } else {
       const {key_id, key} = await api.getPublicKey()

--- a/index.js
+++ b/index.js
@@ -19,21 +19,17 @@ const boostrap = async (api, secret_name, secret_value) => {
     const environmentName = Core.getInput('environment')
     let response
     if (environmentName) {
-      console.error(`environmentName: ${environmentName}`)
       response = await api.getPublicKey(environmentName)
     } else {
       response = await api.getPublicKey()
     }
 
-    console.error(require('util').inspect(response, {depth:null}))
     const key_id = response.key_id
     const key = response.key
-    const data = await api.createSecret(key_id, key, secret_name, secret_value)
-    console.error(require('util').inspect(data, {depth:null}))
 
-    console.error(1)
+    const data = await api.createSecret(key_id, key, secret_name, secret_value)
+
     if (api.isOrg()) {
-      console.error(2)
       data.visibility = Core.getInput('visibility')
 
       if (data.visibility === 'selected') {
@@ -42,8 +38,6 @@ const boostrap = async (api, secret_name, secret_value) => {
     }
 
     if (environmentName) {
-      console.error(3)
-      console.error(`environmentName: ${environmentName}`)
       response = await api.setEnvironmentSecret(data, environmentName, secret_name)
     } else {
       response = await api.setSecret(data, secret_name)

--- a/index.js
+++ b/index.js
@@ -19,12 +19,16 @@ const boostrap = async (api, secret_name, secret_value) => {
     const environmentName = Core.getInput('environment')
     if (environmentName) {
       console.error(`environmentName: ${environmentName}`)
-      const {key_id, key} = await api.getPublicKey(environmentName)
+      const response = await api.getPublicKey(environmentName)
     } else {
-      const {key_id, key} = await api.getPublicKey()
+      const response = await api.getPublicKey()
     }
 
+    console.error(require('util').inspect(response, {depth:null}))
+    const key_id = response.key_id
+    const key = response.key
     const data = await api.createSecret(key_id, key, secret_name, secret_value)
+    console.error(require('util').inspect(data, {depth:null}))
 
     if (api.isOrg()) {
       data.visibility = Core.getInput('visibility')

--- a/index.js
+++ b/index.js
@@ -15,7 +15,12 @@ const Api = require('./src/api')
 const boostrap = async (api, secret_name, secret_value) => {
 
   try {
-    const {key_id, key} = await api.getPublicKey()
+
+    if (environmentName) {
+      const {key_id, key} = await api.getEnvironmentPublicKey(environmentName)
+    } else {
+      const {key_id, key} = await api.getPublicKey()
+    }
 
     const data = await api.createSecret(key_id, key, secret_name, secret_value)
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,12 @@ const boostrap = async (api, secret_name, secret_value) => {
   try {
 
     const environmentName = Core.getInput('environment')
+    let response
     if (environmentName) {
       console.error(`environmentName: ${environmentName}`)
-      const response = await api.getPublicKey(environmentName)
+      response = await api.getPublicKey(environmentName)
     } else {
-      const response = await api.getPublicKey()
+      response = await api.getPublicKey()
     }
 
     console.error(require('util').inspect(response, {depth:null}))
@@ -30,7 +31,9 @@ const boostrap = async (api, secret_name, secret_value) => {
     const data = await api.createSecret(key_id, key, secret_name, secret_value)
     console.error(require('util').inspect(data, {depth:null}))
 
+    console.error(1)
     if (api.isOrg()) {
+      console.error(2)
       data.visibility = Core.getInput('visibility')
 
       if (data.visibility === 'selected') {
@@ -39,6 +42,7 @@ const boostrap = async (api, secret_name, secret_value) => {
     }
     let response
     if (environmentName) {
+      console.error(3)
       console.error(`environmentName: ${environmentName}`)
       response = await api.setEnvironmentSecret(data, environmentName, secret_name)
     } else {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const boostrap = async (api, secret_name, secret_value) => {
 
   try {
 
+    const environmentName = Core.getInput('environment')
     if (environmentName) {
       const {key_id, key} = await api.getEnvironmentPublicKey(environmentName)
     } else {
@@ -31,7 +32,6 @@ const boostrap = async (api, secret_name, secret_value) => {
         data.selected_repository_ids = Core.getInput('selected_repository_ids')
       }
     }
-    const environmentName = Core.getInput('environment')
     let response
     if (environmentName) {
       console.error(`environmentName: ${environmentName}`)

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const boostrap = async (api, secret_name, secret_value) => {
         data.selected_repository_ids = Core.getInput('selected_repository_ids')
       }
     }
-    let response
+
     if (environmentName) {
       console.error(3)
       console.error(`environmentName: ${environmentName}`)

--- a/src/api.js
+++ b/src/api.js
@@ -33,18 +33,20 @@ module.exports = class Api {
       
       console.error(`response: ${require('util').inspect(repo, {depth:null})}`)
 
-      let data = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
+      let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
         repo_id: repo.data.id,
         environmentName: environmentName
       })
 
       console.error(`response: ${require('util').inspect(data, {depth:null})}`)
-    } else {
-      let { data } = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
-        base: this._base,
-        repo: this._repo
-      })
-    } 
+
+      return data
+    }
+
+    let { data } = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
+      base: this._base,
+      repo: this._repo
+    })
 
     return data
   }

--- a/src/api.js
+++ b/src/api.js
@@ -27,7 +27,6 @@ module.exports = class Api {
    */
   async getPublicKey(environmentName) {
     if (environmentName) {
-					async getEnvironmentPublicKey(environmentName) {
 						let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentname/secrets/public-key', {
 							base: this._base,
 							repo: this._repo,

--- a/src/api.js
+++ b/src/api.js
@@ -27,18 +27,18 @@ module.exports = class Api {
    */
   async getPublicKey(environmentName) {
     if (environmentName) {
-            let { repo } = await this.octokit.request('GET /repos/:repo', {
-              repo: this._repo
-            })
-						let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
-							repo_id: repo.id,
-							environmentName
-						})
+      let repo = await this.octokit.request('GET /repos/:repo', {
+        repo: this._repo
+      })
+      let data = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
+        repo_id: repo.id,
+        environmentName: environmentName
+      })
     } else {
-						let { data } = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
-							base: this._base,
-							repo: this._repo
-						})
+      let data = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
+        base: this._base,
+        repo: this._repo
+      })
     } 
 
     return data

--- a/src/api.js
+++ b/src/api.js
@@ -25,18 +25,20 @@ module.exports = class Api {
    *
    * @returns {Promise<{data: object}>} - Fetch response
    */
-  async getPublicKey() {
-    let { data } = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
-      base: this._base,
-      repo: this._repo
-    })
-    
-  async getEnvironmentPublicKey(environmentName) {
-    let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentname/secrets/public-key', {
-      base: this._base,
-      repo: this._repo,
-      environmentName
-    })
+  async getPublicKey(environmentName) {
+    if (environmentName) {
+					async getEnvironmentPublicKey(environmentName) {
+						let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentname/secrets/public-key', {
+							base: this._base,
+							repo: this._repo,
+							environmentName
+						})
+    } else {
+						let { data } = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
+							base: this._base,
+							repo: this._repo
+						})
+    } 
 
     return data
   }

--- a/src/api.js
+++ b/src/api.js
@@ -32,7 +32,8 @@ module.exports = class Api {
       let repo = await this.octokit.request('GET /repos/:repo', {
         repo: this._repo
       })
-      console.error(`response: ${repo}`)
+      
+      console.error(`response: ${require('util').inspect(repo, {depth:null})}`)
       let data = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
         repo_id: repo.id,
         environmentName: environmentName

--- a/src/api.js
+++ b/src/api.js
@@ -32,12 +32,13 @@ module.exports = class Api {
       })
       
       console.error(`response: ${require('util').inspect(repo, {depth:null})}`)
-      console.error(`response: ${repo.data}`)
 
-      let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
+      let data = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
         repo_id: repo.data.id,
         environmentName: environmentName
       })
+
+      console.error(`response: ${require('util').inspect(data, {depth:null})}`)
     } else {
       let data = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
         base: this._base,

--- a/src/api.js
+++ b/src/api.js
@@ -27,9 +27,11 @@ module.exports = class Api {
    */
   async getPublicKey(environmentName) {
     if (environmentName) {
-						let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentName/secrets/public-key', {
-							base: this._base,
-							repo: this._repo,
+            let { repo } = await this.octokit.request('GET /repos/:repo', {
+              repo: this._repo
+            })
+						let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
+							repo_id: repo.id,
 							environmentName
 						})
     } else {

--- a/src/api.js
+++ b/src/api.js
@@ -25,20 +25,16 @@ module.exports = class Api {
    *
    * @returns {Promise<{data: object}>} - Fetch response
    */
-  async getPublicKey(environmentName) {
+  async getPublicKey(environmentName = ) {
     if (environmentName) {
       let repo = await this.octokit.request('GET /repos/:repo', {
         repo: this._repo
       })
-      
-      console.error(`response: ${require('util').inspect(repo, {depth:null})}`)
 
       let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
         repo_id: repo.data.id,
         environmentName: environmentName
       })
-
-      console.error(`response: ${require('util').inspect(data, {depth:null})}`)
 
       return data
     }

--- a/src/api.js
+++ b/src/api.js
@@ -30,6 +30,13 @@ module.exports = class Api {
       base: this._base,
       repo: this._repo
     })
+    
+  async getEnvironmentPublicKey(environmentName) {
+    let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentname/secrets/public-key', {
+      base: this._base,
+      repo: this._repo,
+      environmentName
+    })
 
     return data
   }
@@ -99,3 +106,4 @@ module.exports = class Api {
     return this._org
   }
 }
+

--- a/src/api.js
+++ b/src/api.js
@@ -27,7 +27,7 @@ module.exports = class Api {
    */
   async getPublicKey(environmentName) {
     if (environmentName) {
-						let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentname/secrets/public-key', {
+						let { data } = await this.octokit.request('GET /:base/:repo/environments/:environmentName/secrets/public-key', {
 							base: this._base,
 							repo: this._repo,
 							environmentName

--- a/src/api.js
+++ b/src/api.js
@@ -27,9 +27,12 @@ module.exports = class Api {
    */
   async getPublicKey(environmentName) {
     if (environmentName) {
+      console.error("in getPublicKey")
+      console.error(`repo: ${this._repo}`)
       let repo = await this.octokit.request('GET /repos/:repo', {
         repo: this._repo
       })
+      console.error(`response: ${repo}`)
       let data = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
         repo_id: repo.id,
         environmentName: environmentName

--- a/src/api.js
+++ b/src/api.js
@@ -27,15 +27,15 @@ module.exports = class Api {
    */
   async getPublicKey(environmentName) {
     if (environmentName) {
-      console.error("in getPublicKey")
-      console.error(`repo: ${this._repo}`)
       let repo = await this.octokit.request('GET /repos/:repo', {
         repo: this._repo
       })
       
       console.error(`response: ${require('util').inspect(repo, {depth:null})}`)
-      let data = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
-        repo_id: repo.id,
+      console.error(`response: ${repo.data}`)
+
+      let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
+        repo_id: repo.data.id,
         environmentName: environmentName
       })
     } else {

--- a/src/api.js
+++ b/src/api.js
@@ -40,7 +40,7 @@ module.exports = class Api {
 
       console.error(`response: ${require('util').inspect(data, {depth:null})}`)
     } else {
-      let data = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
+      let { data } = await this.octokit.request('GET /:base/:repo/actions/secrets/public-key', {
         base: this._base,
         repo: this._repo
       })

--- a/src/api.js
+++ b/src/api.js
@@ -25,7 +25,7 @@ module.exports = class Api {
    *
    * @returns {Promise<{data: object}>} - Fetch response
    */
-  async getPublicKey(environmentName = ) {
+  async getPublicKey(environmentName = false) {
     if (environmentName) {
       let repo = await this.octokit.request('GET /repos/:repo', {
         repo: this._repo

--- a/src/api.js
+++ b/src/api.js
@@ -33,7 +33,7 @@ module.exports = class Api {
 
       let { data } = await this.octokit.request('GET /repositories/:repo_id/environments/:environmentName/secrets/public-key', {
         repo_id: repo.data.id,
-        environmentName: environmentName
+        environmentName
       })
 
       return data


### PR DESCRIPTION
The original calls to get the _Environment's_ Public Key were missing, so the secret was never being encrypted. In practice this was resulting in the Secret being created in the Environment, but it would have a blank value.

This (messy) PR addresses this - the _value_ for Environment secrets will now be populated as expected. Nothing that both myself, and the co-author here, are completely n00bs when it comes to JS there are no tests bundled, but we hoped this may help move toward a possible solution!